### PR TITLE
Add functions to support LinkAja Applink

### DIFF
--- a/client.go
+++ b/client.go
@@ -13,10 +13,12 @@ import (
 // Client struct
 type Client struct {
 	BaseUrl    string
+	MerchantId string
 	TerminalId string
 	UserKey    string
 	Password   string
 	Signature  string
+	Key        string
 	LogLevel   int
 	Logger     *log.Logger
 }
@@ -99,7 +101,7 @@ func (c *Client) ExecuteRequest(req *http.Request, v interface{}) error {
 	}
 
 	if logLevel > 2 {
-		logger.Println("LinkAja response: ", resBody)
+		logger.Println("LinkAja response: ", string(resBody))
 	}
 
 	if v != nil && res.StatusCode == 200 {

--- a/common.go
+++ b/common.go
@@ -24,18 +24,13 @@ func PadRight(str string, item string, length int) string {
 	return str + strings.Repeat(item, count)
 }
 
-func PKCS5Padding(data []byte, blockSize int) []byte {
-	padding := blockSize - len(data)%blockSize
+func PKCS5Padding(ciphertext []byte, blockSize int) []byte {
+	padding := blockSize - len(ciphertext)%blockSize
 	padtext := bytes.Repeat([]byte{byte(padding)}, padding)
-	return append(data, padtext...)
+	return append(ciphertext, padtext...)
 }
 
-func PKCS7Padding(data []byte, blockSize int) ([]byte, error) {
-	if blockSize < 0 || blockSize > 256 {
-		return nil, fmt.Errorf("pkcs7: Invalid block size %d", blockSize)
-	}
-
-	padLen := 16 - len(data)%blockSize
-	padding := bytes.Repeat([]byte{byte(padLen)}, padLen)
-	return append(data, padding...), nil
+func PKCS5Trimming(encrypt []byte) []byte {
+	padding := encrypt[len(encrypt)-1]
+	return encrypt[:len(encrypt)-int(padding)]
 }

--- a/common.go
+++ b/common.go
@@ -1,6 +1,10 @@
 package linkaja
 
-import "fmt"
+import (
+	"bytes"
+	"fmt"
+	"strings"
+)
 
 func GenerateItems(items []PublicTokenItemRequest) string {
 	var is string
@@ -12,4 +16,26 @@ func GenerateItems(items []PublicTokenItemRequest) string {
 	}
 
 	return fmt.Sprintf("[%v]", is)
+}
+
+func PadRight(str string, item string, length int) string {
+	strLength := len(strings.TrimSpace(str))
+	count := length - strLength
+	return str + strings.Repeat(item, count)
+}
+
+func PKCS5Padding(data []byte, blockSize int) []byte {
+	padding := blockSize - len(data)%blockSize
+	padtext := bytes.Repeat([]byte{byte(padding)}, padding)
+	return append(data, padtext...)
+}
+
+func PKCS7Padding(data []byte, blockSize int) ([]byte, error) {
+	if blockSize < 0 || blockSize > 256 {
+		return nil, fmt.Errorf("pkcs7: Invalid block size %d", blockSize)
+	}
+
+	padLen := 16 - len(data)%blockSize
+	padding := bytes.Repeat([]byte{byte(padLen)}, padLen)
+	return append(data, padding...), nil
 }

--- a/request.go
+++ b/request.go
@@ -26,6 +26,7 @@ type GenerateApplinkPaymentRequest struct {
 	PartnerTrxID   string `json:"partnerTrxID"`
 	MerchantID     string `json:"merchantID"`
 	TerminalID     string `json:"terminalID"`
+	TerminalName   string `json:"terminalName"`
 	TotalAmount    string `json:"totalAmount"`
 	PartnerApplink string `json:"partnerApplink"`
 	Items          []Item `json:"items"`
@@ -35,4 +36,17 @@ type Item struct {
 	Name      string `json:"name"`
 	UnitPrice string `json:"unitPrice"`
 	Quantity  string `json:"qty"`
+}
+
+type InformPaymentRequest struct {
+	Status         string `json:"status"`
+	Refnum         string `json:"linkAjaRefnum"`
+	TrxDate        string `json:"trxDate"`
+	PartnerTrxID   string `json:"partnerTrxID"`
+	MerchantID     string `json:"merchantID"`
+	TerminalID     string `json:"terminalID"`
+	TerminalName   string `json:"terminalName"`
+	TotalAmount    string `json:"totalAmount"`
+	PartnerApplink string `json:"partnerApplink"`
+	Items          []Item `json:"items"`
 }

--- a/request.go
+++ b/request.go
@@ -20,3 +20,19 @@ type PublicTokenItemRequest struct {
 type TransactionRequest struct {
 	RefNum string
 }
+
+type GenerateApplinkPaymentRequest struct {
+	TrxDate        string `json:"trxDate"`
+	PartnerTrxID   string `json:"partnerTrxID"`
+	MerchantID     string `json:"merchantID"`
+	TerminalID     string `json:"terminalID"`
+	TotalAmount    string `json:"totalAmount"`
+	PartnerApplink string `json:"partnerApplink"`
+	Items          []Item `json:"items"`
+}
+
+type Item struct {
+	Name      string `json:"name"`
+	UnitPrice string `json:"unitPrice"`
+	Quantity  string `json:"qty"`
+}

--- a/responses.go
+++ b/responses.go
@@ -12,3 +12,13 @@ type TransactionResponses struct {
 	TransactionDate string `json:"transactionDate"`
 	Status          string `json:"status"`
 }
+
+type GenerateApplinkPaymentResponse struct {
+	Status  string `json:"status"`
+	Message string `json:"message"`
+	Data    Data   `json:"data"`
+}
+
+type Data struct {
+	URL string `json:"url"`
+}

--- a/sangulinkaja_test.go
+++ b/sangulinkaja_test.go
@@ -1,0 +1,54 @@
+package linkaja
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type SanguLinkajaTestSuite struct {
+	suite.Suite
+}
+
+func TestSanguLinkaja(t *testing.T) {
+	suite.Run(t, new(SanguLinkajaTestSuite))
+}
+
+func (s *SanguLinkajaTestSuite) TestGenerateApplinkPaymentSuccess() {
+	client := NewClient()
+	client.BaseUrl = "--- some string ---"
+	client.MerchantId = "--- some string ---"
+	client.TerminalId = "--- some string ---"
+	client.UserKey = "--- some string ---"
+	client.Password = "--- some string ---"
+	client.Key = "--- some string ---"
+	client.LogLevel = 3
+
+	gateway := CoreGateway{
+		Client: client,
+	}
+
+	req := &GenerateApplinkPaymentRequest{
+		TrxDate:        "--- some string ---",
+		PartnerTrxID:   "--- some string ---",
+		MerchantID:     client.MerchantId,
+		TerminalID:     "--- some string ---",
+		TotalAmount:    "--- some string ---",
+		PartnerApplink: "--- some string ---",
+		Items: []Item{
+			Item{
+				Name:      "--- some string ---",
+				UnitPrice: "--- some string ---",
+				Quantity:  "--- some string ---",
+			},
+		},
+	}
+
+	resp, err := gateway.GenerateApplinkPayment(req)
+
+	assert.Nil(s.T(), err)
+	assert.NotNil(s.T(), resp)
+	assert.Equal(s.T(), "00", resp.Status)
+}

--- a/sangulinkaja_test.go
+++ b/sangulinkaja_test.go
@@ -18,12 +18,12 @@ func TestSanguLinkaja(t *testing.T) {
 
 func (s *SanguLinkajaTestSuite) TestGenerateApplinkPaymentSuccess() {
 	client := NewClient()
-	client.BaseUrl = "--- some string ---"
-	client.MerchantId = "--- some string ---"
-	client.TerminalId = "--- some string ---"
-	client.UserKey = "--- some string ---"
-	client.Password = "--- some string ---"
-	client.Key = "--- some string ---"
+	client.BaseUrl = "some-string"
+	client.MerchantId = "some-string"
+	client.TerminalId = "some-string"
+	client.UserKey = "some-string"
+	client.Password = "some-string"
+	client.Key = "some-string"
 	client.LogLevel = 3
 
 	gateway := CoreGateway{
@@ -31,22 +31,47 @@ func (s *SanguLinkajaTestSuite) TestGenerateApplinkPaymentSuccess() {
 	}
 
 	req := &GenerateApplinkPaymentRequest{
-		TrxDate:        "--- some string ---",
-		PartnerTrxID:   "--- some string ---",
+		TrxDate:        "some-string",
+		PartnerTrxID:   "some-string",
 		MerchantID:     client.MerchantId,
-		TerminalID:     "--- some string ---",
-		TotalAmount:    "--- some string ---",
-		PartnerApplink: "--- some string ---",
+		TerminalID:     "some-string",
+		TotalAmount:    "some-string",
+		PartnerApplink: "some-string",
 		Items: []Item{
 			Item{
-				Name:      "--- some string ---",
-				UnitPrice: "--- some string ---",
-				Quantity:  "--- some string ---",
+				Name:      "some-string",
+				UnitPrice: "some-string",
+				Quantity:  "some-string",
 			},
 		},
 	}
 
 	resp, err := gateway.GenerateApplinkPayment(req)
+
+	assert.Nil(s.T(), err)
+	assert.NotNil(s.T(), resp)
+	assert.Equal(s.T(), "00", resp.Status)
+}
+
+func (s *SanguLinkajaTestSuite) TestDecryptInformPaymentSuccess() {
+	client := NewClient()
+	client.BaseUrl = "some-string"
+	client.MerchantId = "some-string"
+	client.TerminalId = "some-string"
+	client.UserKey = "some-string"
+	client.Password = "some-string"
+	client.Key = "some-string"
+	client.LogLevel = 3
+
+	gateway := CoreGateway{
+		Client: client,
+	}
+
+	encrypted := "some-string"
+	auth := "some-string"
+	timestamp := "some-string"
+
+	resp, err := gateway.DecryptInformPaymentRequest(encrypted, auth, timestamp)
 
 	assert.Nil(s.T(), err)
 	assert.NotNil(s.T(), resp)


### PR DESCRIPTION
1. Add method `GenerateApplinkPayment` to encrypt request and send it to LinkAja generate applink payment endpoint.
2. Add method `DecryptInformPaymentRequest` to decrypt callback request from LinkAja.